### PR TITLE
Align dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,38 @@
   <description>SmallRye Parent POM</description>
   <url>http://smallrye.io</url>
 
+  <inceptionYear>2018</inceptionYear>
+
   <packaging>pom</packaging>
 
   <properties>
+    <!-- Dependency versions -->
+    <version.javax.javaee-api>8.0.1</version.javax.javaee-api>
+    <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
+    <version.javax.enterprise.cdi-api>2.0.SP1</version.javax.enterprise.cdi-api>
+    <version.javax.json.api>1.1.4</version.javax.json.api>
+    <version.javax.json.bind>1.0</version.javax.json.bind>
+    <version.javax.ws.rs-api>2.1.1</version.javax.ws.rs-api>
+    <version.org.jboss.logging>3.4.0.Final</version.org.jboss.logging>
+    <version.org.jboss.logging-processor>2.2.0.Final</version.org.jboss.logging-processor>
+    <version.weld.api>3.1.Final</version.weld.api>
+    <version.weld.core>3.1.0.Final</version.weld.core>
+
+    <!-- Testing versions -->
+    <version.assertj>3.12.2</version.assertj>
+    <version.awaitility>3.1.6</version.awaitility>
+    <version.org.jboss.arquillian>1.4.1.Final</version.org.jboss.arquillian>
+    <version.org.jboss.arquillian.container.weld-embedded>2.0.1.Final</version.org.jboss.arquillian.container.weld-embedded>
+    <version.org.jboss.arquillian.wildfly>2.2.0.Final</version.org.jboss.arquillian.wildfly>
+    <version.junit>4.12</version.junit>
+    <version.testng>6.14.3</version.testng>
+    <version.testcontainers>1.11.2</version.testcontainers>
+    <version.wildfly>16.0.0.Final</version.wildfly>
+
     <!-- Plugin versions -->
+    <version.asciidoctor.plugin>1.6.0</version.asciidoctor.plugin>
     <version.gpg.plugin>1.6</version.gpg.plugin>
+    <version.jar.plugin>3.1.1</version.jar.plugin>
     <version.javadoc.plugin>3.1.0</version.javadoc.plugin>
     <version.nexus.staging.plugin>1.6.8</version.nexus.staging.plugin>
     <version.release.plugin>2.5.3</version.release.plugin>
@@ -71,6 +98,128 @@
     </repository>
   </distributionManagement>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Java EE -->
+      <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+        <version>${version.javax.javaee-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>${version.javax.enterprise.cdi-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs-api</artifactId>
+        <version>${version.javax.ws.rs-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${version.javax.annotation-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.json.bind</groupId>
+        <artifactId>javax.json.bind-api</artifactId>
+        <version>${version.javax.json.bind}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.json</groupId>
+        <artifactId>javax.json-api</artifactId>
+        <version>${version.javax.json.api}</version>
+      </dependency>
+
+      <!-- Weld -->
+      <dependency>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-spi</artifactId>
+        <version>${version.weld.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-api</artifactId>
+        <version>${version.weld.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-core-impl</artifactId>
+        <version>${version.weld.core}</version>
+      </dependency>
+
+      <!-- Logging -->
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${version.org.jboss.logging}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-annotations</artifactId>
+        <version>${version.org.jboss.logging-processor}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-processor</artifactId>
+        <version>${version.org.jboss.logging-processor}</version>
+      </dependency>
+
+      <!-- Testing -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+        <version>${version.junit}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>${version.testng}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${version.awaitility}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.testcontainers}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.org.jboss.arquillian}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>arquillian-weld-embedded</artifactId>
+        <version>${version.org.jboss.arquillian.container.weld-embedded}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-container-managed</artifactId>
+        <version>${version.org.jboss.arquillian.wildfly}</version>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>
@@ -105,6 +254,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>${version.gpg.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${version.jar.plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -161,6 +315,20 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.asciidoctor</groupId>
+          <artifactId>asciidoctor-maven-plugin</artifactId>
+          <version>${version.asciidoctor.plugin}</version>
+          <configuration>
+            <backend>html</backend>
+            <sourceHighlighter>highlightjs</sourceHighlighter>
+            <imagesDir>assets</imagesDir>
+            <attributes>
+              <version>${project.version}</version>
+              <organization>${project.organization.name}</organization>
+            </attributes>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Add common MP and SmallRye dependencies into the parent so versions can be aligned between all specifications