### PR TITLE
Add profiles for formatting #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.*
+!/.gitignore
+!*.gitkeep
+!.mvn
 target
-.idea
+*.log
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,49 @@
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>${version.nexus.staging.plugin}</version>
         </plugin>
+        <plugin>
+          <groupId>net.revelc.code.formatter</groupId>
+          <artifactId>formatter-maven-plugin</artifactId>
+          <version>2.8.1</version>
+            <dependencies>
+              <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-code-rules</artifactId>
+                <version>1-SNAPSHOT</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <configFile>io/smallrye/coderules/eclipse-format.xml</configFile>
+              <skip>${format.skip}</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.revelc.code</groupId>
+            <artifactId>impsort-maven-plugin</artifactId>
+            <version>1.2.0</version>
+            <configuration>
+              <groups>java.,javax.,org.,com.</groups>
+              <staticGroups>*</staticGroups>
+              <skip>${format.skip}</skip>
+              <removeUnused>true</removeUnused>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sort-imports</id>
+                <goals>
+                  <goal>sort</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -345,49 +345,6 @@
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>${version.nexus.staging.plugin}</version>
         </plugin>
-        <plugin>
-          <groupId>net.revelc.code.formatter</groupId>
-          <artifactId>formatter-maven-plugin</artifactId>
-          <version>${version.formatter.plugin}</version>
-            <dependencies>
-              <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-code-rules</artifactId>
-                <version>${version.smallrye.code.rules.plugin}</version>
-              </dependency>
-            </dependencies>
-            <configuration>
-              <configFile>io/smallrye/coderules/eclipse-format.xml</configFile>
-              <skip>${format.skip}</skip>
-            </configuration>
-            <executions>
-              <execution>
-                <phase>process-sources</phase>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>net.revelc.code</groupId>
-            <artifactId>impsort-maven-plugin</artifactId>
-            <version>${version.impsort.plugin}</version>
-            <configuration>
-              <groups>java.,javax.,org.,com.</groups>
-              <staticGroups>*</staticGroups>
-              <skip>${format.skip}</skip>
-              <removeUnused>true</removeUnused>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sort-imports</id>
-                <goals>
-                  <goal>sort</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
       </plugins>
     </pluginManagement>
 
@@ -412,6 +369,49 @@
             <id>attach-sources</id>
             <goals>
               <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+        <version>${version.formatter.plugin}</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-code-rules</artifactId>
+            <version>${version.smallrye.code.rules.plugin}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configFile>io/smallrye/coderules/eclipse-format.xml</configFile>
+          <skip>${format.skip}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>impsort-maven-plugin</artifactId>
+        <version>${version.impsort.plugin}</version>
+        <configuration>
+          <groups>java.,javax.,org.,com.</groups>
+          <staticGroups>*</staticGroups>
+          <skip>${format.skip}</skip>
+          <removeUnused>true</removeUnused>
+        </configuration>
+        <executions>
+          <execution>
+            <id>sort-imports</id>
+            <goals>
+              <goal>sort</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,9 @@
     <version.release.plugin>2.5.3</version.release.plugin>
     <version.source.plugin>3.1.0</version.source.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
+    <version.smallrye.code.rules.plugin>1</version.smallrye.code.rules.plugin>
+    <version.formatter.plugin>2.8.1</version.formatter.plugin>
+    <version.impsort.plugin>1.2.0</version.impsort.plugin>
 
     <!-- Cross plugins settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -345,12 +348,12 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.8.1</version>
+          <version>${version.formatter.plugin}</version>
             <dependencies>
               <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-code-rules</artifactId>
-                <version>1-SNAPSHOT</version>
+                <version>${version.smallrye.code.rules.plugin}</version>
               </dependency>
             </dependencies>
             <configuration>
@@ -369,7 +372,7 @@
           <plugin>
             <groupId>net.revelc.code</groupId>
             <artifactId>impsort-maven-plugin</artifactId>
-            <version>1.2.0</version>
+            <version>${version.impsort.plugin}</version>
             <configuration>
               <groups>java.,javax.,org.,com.</groups>
               <staticGroups>*</staticGroups>


### PR DESCRIPTION
Fixes #15 

Adds configurations for the "formatter-maven-plugin" and the "impsort-maven-plugin" in the plugin management section. This means the plugins are fully configured, but not activated.

The  "formatter-maven-plugin" references the new [smallrye-code-rules](https://github.com/smallrye/smallrye-code-rules) as a plugin dependency.

Every project has to add itself the two plugins to activate them:
```xml
<build>
    <plugins>             
        <plugin>
            <groupId>net.revelc.code.formatter</groupId>
            <artifactId>formatter-maven-plugin</artifactId>
        </plugin>
        <plugin>
            <groupId>net.revelc.code</groupId>
            <artifactId>impsort-maven-plugin</artifactId>
        </plugin>
    </plugins>
</build>
```
This allows every project to decide itself when to start with the standard formatting. 
