### PR TITLE
Enable builds to run on JDK9 and after using release flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <!-- maven-compiler-plugin -->
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <version.maven.compiler.release>8</version.maven.compiler.release>
     <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
     <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
   </properties>
@@ -440,6 +441,15 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${version.maven.compiler.release}</maven.compiler.release>
+      </properties>
+    </profile>
     <profile>
       <id>release</id>
       <build>


### PR DESCRIPTION
This PR enables builds to run using JDK9 and after by using the `release` compiler option to produce Java 8 output. The intent is not to change downstream projects to use Java 9+ at this time, but merely to support the build process using a JDK that accepts `release`.