### PR TITLE
Add JBoss public repo as a plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,6 +456,17 @@
     </plugins>
   </build>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-public-repository</id>
+      <name>JBoss Public Maven Repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <profiles>
     <profile>
       <id>jdk9</id>


### PR DESCRIPTION
As we now depend on `org.apache.maven.plugins:maven-compiler-plugin:3.8.1-jboss-1` we need the JBoss repo imported