### PR TITLE
Remove testing dependencies used mostly for MicroProfile TCKs

### DIFF
--- a/full-parent-jakarta/pom.xml
+++ b/full-parent-jakarta/pom.xml
@@ -31,24 +31,14 @@
 
         <version.org.jboss.logging>3.5.0.Final</version.org.jboss.logging>
         <version.org.jboss.logging-processor>2.2.1.Final</version.org.jboss.logging-processor>
-        <version.weld.api>4.0.SP1</version.weld.api>
-        <version.weld.core>4.0.3.Final</version.weld.core>
         <version.org.jboss.jandex>2.4.3.Final</version.org.jboss.jandex>
-        <version.glassfish.json>2.0.1</version.glassfish.json>
 
         <!-- Testing versions -->
         <version.assertj>3.24.2</version.assertj>
         <version.awaitility>4.2.0</version.awaitility>
-        <version.org.jboss.arquillian>1.7.0.Alpha10</version.org.jboss.arquillian>
-        <version.org.jboss.arquillian.container.weld-embedded>3.0.1.Final</version.org.jboss.arquillian.container.weld-embedded>
-        <version.org.jboss.arquillian.wildfly>5.0.0.Alpha2</version.org.jboss.arquillian.wildfly>
-        <version.junit>4.13.2</version.junit>
         <version.junit5>5.9.2</version.junit5>
-        <version.weld.junit>3.0.0.Final</version.weld.junit>
         <version.rest-assured>4.5.1</version.rest-assured>
-        <version.testng>7.7.0</version.testng>
         <version.testcontainers>1.17.6</version.testcontainers>
-        <version.wildfly>18.0.1.Final</version.wildfly>
     </properties>
 
     <dependencyManagement>
@@ -90,30 +80,6 @@
                 <version>${version.jakarta.jms.api}</version>
             </dependency>
 
-            <!-- Weld -->
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-spi</artifactId>
-                <version>${version.weld.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-api</artifactId>
-                <version>${version.weld.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-core-impl</artifactId>
-                <version>${version.weld.core}</version>
-            </dependency>
-
-            <!-- Glassfish -->
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.json</artifactId>
-                <version>${version.glassfish.json}</version>
-            </dependency>
-
             <!-- Logging -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -141,17 +107,6 @@
 
             <!-- Testing -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <scope>test</scope>
-                <version>${version.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-junit4</artifactId>
-                <version>${version.weld.junit}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${version.junit5}</version>
@@ -168,18 +123,6 @@
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>${version.junit5}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-junit5</artifactId>
-                <version>${version.weld.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.testng}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -204,25 +147,6 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${version.testcontainers}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.org.jboss.arquillian}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian.container</groupId>
-                <artifactId>arquillian-weld-embedded</artifactId>
-                <version>${version.org.jboss.arquillian.container.weld-embedded}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <version>${version.org.jboss.arquillian.wildfly}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/full-parent/pom.xml
+++ b/full-parent/pom.xml
@@ -31,24 +31,14 @@
 
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logging-processor>2.2.1.Final</version.org.jboss.logging-processor>
-        <version.weld.api>3.1.Final</version.weld.api>
-        <version.weld.core>3.1.7.SP1</version.weld.core>
         <version.org.jboss.jandex>2.4.3.Final</version.org.jboss.jandex>
-        <version.glassfish.json>1.1.6</version.glassfish.json>
 
         <!-- Testing versions -->
         <version.assertj>3.24.2</version.assertj>
         <version.awaitility>4.2.0</version.awaitility>
-        <version.org.jboss.arquillian>1.6.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.arquillian.container.weld-embedded>2.1.0.Final</version.org.jboss.arquillian.container.weld-embedded>
-        <version.org.jboss.arquillian.wildfly>3.0.1.Final</version.org.jboss.arquillian.wildfly>
-        <version.junit>4.13.2</version.junit>
         <version.junit5>5.9.2</version.junit5>
-        <version.weld.junit>2.0.2.Final</version.weld.junit>
         <version.rest-assured>4.5.1</version.rest-assured>
-        <version.testng>6.14.3</version.testng>
         <version.testcontainers>1.17.6</version.testcontainers>
-        <version.wildfly>18.0.1.Final</version.wildfly>
     </properties>
 
     <dependencyManagement>
@@ -90,30 +80,6 @@
                 <version>${version.jakarta.jms.api}</version>
             </dependency>
 
-            <!-- Weld -->
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-spi</artifactId>
-                <version>${version.weld.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-api</artifactId>
-                <version>${version.weld.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-core-impl</artifactId>
-                <version>${version.weld.core}</version>
-            </dependency>
-
-            <!-- Glassfish -->
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.json</artifactId>
-                <version>${version.glassfish.json}</version>
-            </dependency>
-
             <!-- Logging -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -141,18 +107,6 @@
 
             <!-- Testing -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <scope>test</scope>
-                <version>${version.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-junit4</artifactId>
-                <version>${version.weld.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${version.junit5}</version>
@@ -169,18 +123,6 @@
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>${version.junit5}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-junit5</artifactId>
-                <version>${version.weld.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.testng}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -205,25 +147,6 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${version.testcontainers}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.org.jboss.arquillian}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian.container</groupId>
-                <artifactId>arquillian-weld-embedded</artifactId>
-                <version>${version.org.jboss.arquillian.container.weld-embedded}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <version>${version.org.jboss.arquillian.wildfly}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- Fixes #317 
- [ ] Requires to update most SmallRye projects with the Testing BOM
- [x] Requires https://github.com/smallrye/smallrye-testing/pull/27