### PR TITLE
Repository id update and release version 42

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Parent
 release:
-  current-version: 41
-  next-version: 42-SNAPSHOT
+  current-version: 42
+  next-version: 43-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,11 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
+      <id>oss.sonatype</id>
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
     </snapshotRepository>
     <repository>
-      <id>ossrh</id>
+      <id>oss.sonatype</id>
       <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>


### PR DESCRIPTION
- Use oss.sonatype as the Sonatype repository id
- Release version 42
