### PR TITLE
Fix Javadoc config for MR JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,14 +511,9 @@
           </plugin>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default</id>
-                <configuration>
-                  <source>11</source>
-                </configuration>
-              </execution>
-            </executions>
+            <configuration>
+              <source>11</source>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -593,14 +588,9 @@
           </plugin>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default</id>
-                <configuration>
-                  <source>17</source>
-                </configuration>
-              </execution>
-            </executions>
+            <configuration>
+              <source>17</source>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -675,14 +665,9 @@
           </plugin>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default</id>
-                <configuration>
-                  <source>21</source>
-                </configuration>
-              </execution>
-            </executions>
+            <configuration>
+              <source>21</source>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Currently, only the `default` execution of the `javadoc` plugin will be configured with the release version. However, at least one SmallRye project has a `quality` build check which makes javadocs using the `javadoc` goal which does not use this execution configuration. In reality, the target release should always determine the version used for every `javadoc` invocation strategy.