### PR TITLE
Add explicit jboss-logging-processor reference to compiler plugin

### DIFF
--- a/full-parent/pom.xml
+++ b/full-parent/pom.xml
@@ -24,7 +24,6 @@
         <version.jakarta.ws.rs.api>3.1.0</version.jakarta.ws.rs.api>
 
         <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
-        <version.org.jboss.logging-processor>3.0.3.Final</version.org.jboss.logging-processor>
         <version.org.jboss.jandex>3.0.5</version.org.jboss.jandex>
 
         <!-- Testing versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.jacoco.plugin>0.8.12</version.jacoco.plugin>
     <version.buildnumber.plugin>3.2.1</version.buildnumber.plugin>
     <version.versions.plugin>2.18.0</version.versions.plugin>
+    <version.org.jboss.logging-processor>3.0.3.Final</version.org.jboss.logging-processor>
 
     <!-- Cross plugins settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -292,6 +293,13 @@
               <compilerArgs>
                 <arg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</arg>
               </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.jboss.logging</groupId>
+                  <artifactId>jboss-logging-processor</artifactId>
+                  <version>${version.org.jboss.logging-processor}</version>
+                </path>
+              </annotationProcessorPaths>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
JDK 23 changed the default annotation processing policy - https://inside.java/2024/06/18/quality-heads-up/#:~:text=Starting%20with%20JDK%2023%2C%20at,the%20default%20on%20JDK%2023.

This breaks tests in sr-health on JDK 23, so we need to declare the annotation processor explicitly.