### PR TITLE
Use the correct goal for test compilations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
                 <id>default-testCompile</id>
                 <phase>test-compile</phase>
                 <goals>
-                  <goal>compile</goal>
+                  <goal>testCompile</goal>
                 </goals>
                 <configuration>
                   <release>11</release>
@@ -555,7 +555,7 @@
                 <id>default-testCompile</id>
                 <phase>test-compile</phase>
                 <goals>
-                  <goal>compile</goal>
+                  <goal>testCompile</goal>
                 </goals>
                 <configuration>
                   <release>17</release>
@@ -632,7 +632,7 @@
                 <id>default-testCompile</id>
                 <phase>test-compile</phase>
                 <goals>
-                  <goal>compile</goal>
+                  <goal>testCompile</goal>
                 </goals>
                 <configuration>
                   <release>21</release>


### PR DESCRIPTION
We have been using the `compile` goal instead of the `testCompile` goal for test compilations, which results in some strange and subtle problems.

See also jboss/jboss-parent-pom#393.