### PR TITLE
Move jboss-logging compiler config from execution-level to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,19 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.compiler.plugin}</version>
+          <configuration>
+            <!-- Ensure that the logging generator does not generate invalid annotations -->
+            <compilerArgs>
+              <arg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</arg>
+            </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-processor</artifactId>
+                <version>${version.org.jboss.logging-processor}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -281,31 +294,6 @@
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <!-- Ensure that the logging generator does not generate invalid annotations -->
-            <configuration>
-              <compilerArgs>
-                <arg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</arg>
-              </compilerArgs>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>org.jboss.logging</groupId>
-                  <artifactId>jboss-logging-processor</artifactId>
-                  <version>${version.org.jboss.logging-processor}</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Prevents child projects plugin-level compilerArgs and annotationProcessorPaths from being silently overridden by the parent default-compile execution.
