### PR TITLE
Manage plugin versions correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <version.buildnumber.plugin>3.3.0</version.buildnumber.plugin>
     <version.versions.plugin>2.21.0</version.versions.plugin>
     <version.org.jboss.logging-processor>3.0.4.Final</version.org.jboss.logging-processor>
+    <version.javaparser>3.28.1</version.javaparser>
 
     <!-- Cross plugins settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -277,6 +278,30 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>net.revelc.code.formatter</groupId>
+          <artifactId>formatter-maven-plugin</artifactId>
+          <version>${version.formatter.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>io.smallrye</groupId>
+              <artifactId>smallrye-code-rules</artifactId>
+              <version>${version.smallrye.code.rules.plugin}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>net.revelc.code</groupId>
+          <artifactId>impsort-maven-plugin</artifactId>
+          <version>${version.impsort.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.github.javaparser</groupId>
+              <artifactId>javaparser-core</artifactId>
+              <version>${version.javaparser}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -336,13 +361,6 @@
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
         <version>${version.formatter.plugin}</version>
-        <dependencies>
-          <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-code-rules</artifactId>
-            <version>${version.smallrye.code.rules.plugin}</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <configFile>io/smallrye/coderules/eclipse-format.xml</configFile>
           <skip>${format.skip}</skip>


### PR DESCRIPTION
Also, add an explicit dependency for `javaparser` because it releases more quickly than the formatter plugin does